### PR TITLE
[codex] Modernize CI workflow actions

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -7,16 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          node-version: 20
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Run lint script
@@ -25,16 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          node-version: 20
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Run build
@@ -43,16 +33,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          node-version: 20
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Run build


### PR DESCRIPTION
## Summary

Modernizes the GitHub Actions workflow used by `rinzler` commit checks.

- upgrades `actions/checkout` from v2 to v4
- upgrades `actions/setup-node` from v1 to v4
- runs checks on Node 20 instead of Node 12
- uses `setup-node`'s npm cache instead of caching `node_modules`

## Why

Dependabot PRs are currently blocked because every Commit Checks job fails during the setup step before project commands run. The workflow still uses old action majors and Node 12 on `ubuntu-latest`, so this isolates the CI-platform issue before dependency PRs are merged.

## Verification

Not run locally; this is a GitHub Actions workflow-only change published through the GitHub app. The PR's own Actions run is the relevant verification.